### PR TITLE
MAINT: notebooks will be stored in IAB-notebooks, rather than top-level dir

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -15,7 +15,7 @@ ENV DISPLAY=:99
 RUN apt-get update
 RUN apt-get install -y xvfb x11-utils
 
-COPY IAB-notebooks ${HOME}
+COPY IAB-notebooks ${HOME}/IAB-notebooks/
 # `fix-permissions` ships with jupyter/minimal-notebook
 RUN fix-permissions ${HOME}
 RUN rm -rf work

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -15,7 +15,7 @@ ENV DISPLAY=:99
 RUN apt-get update
 RUN apt-get install -y xvfb x11-utils
 
-COPY IAB-notebooks* ${HOME}
+COPY IAB-notebooks ${HOME}
 # `fix-permissions` ships with jupyter/minimal-notebook
 RUN fix-permissions ${HOME}
 RUN rm -rf work


### PR DESCRIPTION
Currently the notebooks live in the top-level directory of the Docker container, which is different than where they live in the `built-iab` repo. For convenience, I like to provide Binder links like either:

https://mybinder.org/v2/gh/applied-bioinformatics/built-iab/master?filepath=IAB-notebooks%2Findex.ipynb

or 

https://mybinder.org/v2/gh/applied-bioinformatics/built-iab/master?filepath=index.ipynb

so that when Binder loads, the user lands on the top-level index notebook. However, since the notebooks live in the top-level directory in the Docker container and the IAB-notebooks directory in `built-iab`, the first link raises a 404 when Binder is done loading, and the second link raises a 404 in the nbviewer preview while Binder is loading. 

This PR retains the `IAB-notebooks` directory in the Docker container so the first link above won't 404 before or after Binder loads. 

@thermokarst, would you mind testing this locally? I don't have a good test environment for this. 

